### PR TITLE
Updating config from gems to plugins

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,7 +39,8 @@ paginate_path: /page:num/
 
 # Build settings
 markdown: kramdown
-gems:
+
+plugins:
   - jekyll-paginate
   - jekyll-feed
   - jekyll-sitemap


### PR DESCRIPTION
"Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly."