### PR TITLE
Add npm dev script to use local gulp installation rather than the global

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
     "gulp-imagemin": "^3.2.0",
     "gulp-sass": "^3.1.0",
     "imagemin-pngquant": "^5.0.0"
+  },
+  "scripts": {
+    "dev": "node_modules\\.bin\\gulp watch"
   }
 }


### PR DESCRIPTION
First of all, thanks for sharing this theme! :smile:

I'll be submitting some suggested improvements that I used to customize the website I built on top of this theme. Feel free to give some feedback.

This first improvement allows the project to be used without a global gulp installation, by using the short command `npm run dev`.