### PR TITLE
Exclude files that don't have to be published on the web server.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -46,4 +46,4 @@ plugins:
   - jekyll-sitemap
 
 include: [_pages]
-exclude: ["node_modules", "gulpfile.js", "package.json", "yarn.lock"]
+exclude: ["node_modules", "gulpfile.js", "package.json", "yarn.lock", "package-lock.json", "assets/css/sass/"]


### PR DESCRIPTION
The sass-folder can for example be removed since it's only transpiled CSS that is used by browsers.

Not sure if `Gemfile` and `Gemfile.lock` also can be excluded, since they might be used by GitHub Pages to build the page. It would however make more sense if they only used `Gemfile` from the src repository itself.

It feels like publishing `Gemfile` to the public version of the website could be a security risk - although probably not that much for a static page 😅 